### PR TITLE
Small tweek in seed_from_gml to make it work with matplotlib after 1.2.0

### DIFF
--- a/models/openoil.py
+++ b/models/openoil.py
@@ -466,7 +466,13 @@ class OpenOil(OpenDriftSimulation):
 
         # Specific imports
         import datetime
-        import matplotlib.nxutils as nx
+        # nxutils: Deprecated since version 1.2.0: Use contains_points() instead.
+        have_nx=True
+        try:
+            import matplotlib.nxutils as nx
+        except:
+            have_nx=False
+            from matplotlib.path import Path
         from xml.etree import ElementTree
         from matplotlib.patches import Polygon
         from mpl_toolkits.basemap import pyproj
@@ -546,7 +552,10 @@ class OpenOil(OpenDriftSimulation):
             lon = lon.ravel()
             lat = lat.ravel()
             points = np.c_[lon, lat]
-            ind = nx.points_inside_poly(points, slick.xy)
+            if have_nx:
+                ind = nx.points_inside_poly(points, slick.xy)
+            else:
+                ind = Path(slick.xy).contains_points(points)
             lonpoints = np.append(lonpoints, lon[ind])
             latpoints = np.append(latpoints, lat[ind])
 


### PR DESCRIPTION
If you are interested in making seed_from_gml work for newer versions of matplotlib Knut-Frode.