### PR TITLE
Fixed bug in roms reader when reading the hc parameter

### DIFF
--- a/readers/reader_ROMS_native.py
+++ b/readers/reader_ROMS_native.py
@@ -91,7 +91,7 @@ class Reader(Reader):
 
             # Read sigma-coordinate transform parameters
             self.Cs_r = self.Dataset.variables['Cs_r'][:]
-            self.hc = self.Dataset.variables['hc'][:]
+            self.hc = self.Dataset.variables['hc'][0]
 
             self.num_layers = len(self.sigma)
         else:


### PR DESCRIPTION
This fixes a bug with reading the hc parameter from netcdf (see below). 

```
======================================================================
ERROR: test_interpolation_missing (readers.test_interpolation.TestInterpolation)
Test interpolation.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\anbro\Documents\projects\opendrift\readers\test_interpolation.py", line 225, in test_interpolation_missing
    '/../test_data/2Feb2016_Nordic_sigma_3d/Nordic-4km_SLEVELS_avg_00_subset2Feb2016.nc')
  File "C:\Users\anbro\Documents\projects\opendrift\readers\reader_ROMS_native.py", line 94, in __init__
    self.hc = self.Dataset.variables['hc'][:]
  File "netCDF4.pyx", line 2814, in netCDF4.Variable.__getitem__ (netCDF4.c:35116)
TypeError: Cannot cast ufunc add output from dtype('float64') to dtype('int16') with casting rule 'same_kind'
```